### PR TITLE
Fix bad results when compiling with Apple’s LLVM 5

### DIFF
--- a/strsplit.h
+++ b/strsplit.h
@@ -9,7 +9,8 @@ int
 strsplit (char *str, char *parts[], char *delimiter) {
   char *pch;
   int i = 0;
-  pch = strtok(str, delimiter);
+  char *tmp = strdup(str);
+  pch = strtok(tmp, delimiter);
 
   parts[i++] = strdup(pch);
 
@@ -19,6 +20,7 @@ strsplit (char *str, char *parts[], char *delimiter) {
     parts[i++] = strdup(pch);
   }
 
+  free(tmp);
   free(pch);
   return i;
 }


### PR DESCRIPTION
Not entirely sure how this makes any difference, but it this patch makes `strsplit` work properly with Apple’s latest C stack.

Per some googling:

> strtok() is destructive in its parsing (ie it writes to the string you're parsing while you're parsing it)

See #2 and #3.
