### PR TITLE
Use str_copy instead of strdup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 
+SRC := strsplit.c
+SRC += deps/*/*.c
+
 all: clean test
 
 clean:
 	rm -f strsplit-test
 
 test:
-	$(CC) strsplit.c test.c -std=c99 -o strsplit-test
+	$(CC) $(SRC) test.c -std=c99 -o strsplit-test -Ideps
 	./strsplit-test

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "description": "Split a string into a char array by a given delimiter",
   "keywords": ["string", "split"],
   "license": "MIT",
-  "src": ["strsplit.h", "strsplit.c"]
+  "src": ["strsplit.h", "strsplit.c"],
+  "dependencies": {
+    "stephenmathieson/str-copy.c": "*"
+  }
 }

--- a/strsplit.c
+++ b/strsplit.c
@@ -2,20 +2,21 @@
 #include <stdlib.h>
 #include <string.h>
 #include "strsplit.h"
+#include "str-copy/str-copy.h"
 
 int
 strsplit (const char *str, char *parts[], const char *delimiter) {
   char *pch;
   int i = 0;
-  char *tmp = strdup(str);
+  char *tmp = str_copy(str);
   pch = strtok(tmp, delimiter);
 
-  parts[i++] = strdup(pch);
+  parts[i++] = str_copy(pch);
 
   while (pch) {
     pch = strtok(NULL, delimiter);
     if (NULL == pch) break;
-    parts[i++] = strdup(pch);
+    parts[i++] = str_copy(pch);
   }
 
   free(tmp);


### PR DESCRIPTION
Since strdup is not standardized in ANSI C, use str_copy instead.
